### PR TITLE
Use include_str! instead of runtime read

### DIFF
--- a/src/day01.rs
+++ b/src/day01.rs
@@ -13,7 +13,8 @@ fn file_lines(name: &str) -> Vec<String> {
 
 fn part1() -> i32 {
     const GOAL: i32 = 2020;
-    let nums: Vec<_> = file_lines("./inputs/day1.txt")
+    let nums: Vec<_> = include_str!("./inputs/day1.txt")
+        .split('\n')
         .into_iter()
         .map(|e| e.parse::<i32>().unwrap())
         .collect();

--- a/src/day13.rs
+++ b/src/day13.rs
@@ -4,9 +4,8 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 
 fn get_inputs() -> (i32, Vec<Option<i32>>) {
-    let lines: Vec<_> = BufReader::new(File::open("./inputs/day13.txt").unwrap())
+    let lines: Vec<_> = include_str!("./inputs/day13.txt")
         .lines()
-        .map(|l| l.expect("Could not parse line"))
         .collect();
 
     (


### PR DESCRIPTION
Changed line 7 to use include_str! instead of a runtime file read. It's vaguely faster